### PR TITLE
fix NoneType AttributeError of optimization_options

### DIFF
--- a/flowpaths/minflowdecomp.py
+++ b/flowpaths/minflowdecomp.py
@@ -30,7 +30,7 @@ class MinFlowDecomp(pathmodel.AbstractPathModelDAG): # Note that we inherit from
         subpath_constraints_coverage_length: float = None,
         edge_length_attr: str = None,
         edges_to_ignore: list = [],
-        optimization_options: dict = None,
+        optimization_options: dict = {},
         solver_options: dict = None,
     ):
         """


### PR DESCRIPTION
Most of the code in the examples directory fails at the moment due to the optimization_options variable being None.
I suggest to change the default to an empty dictionary.

Reproduce: Run, for example, `python3 ./examples/min_flow_decomp.py`.